### PR TITLE
Support optional use of decorators when when creating registrations

### DIFF
--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -351,6 +351,9 @@ export interface IInjectionConfiguration<T = any> {
      */
     resolution?: IExternalResolutionConfiguration<T> | T;
 
+    /**
+     * You can provide explicit metadata for a type using this property.  Note if you are not leveraging decorators with 'emitDecoratorMetadata' you must provide all metadata for a given type
+     */
     metadata?: any[];
 }
 

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -306,6 +306,13 @@ export interface IInjector {
     getRegisteredTypesWithDependencies(): Array<{ provide: any; deps: Array<any> }>;
 
     /**
+     * Resolves the nearest injector in our hierarchy that has a registration for the given type or token
+     * @param injector The starting point injector
+     * @param tokenOrType The type of the token we are looking for
+     */
+    getInjectorForTypeOrToken(injector: IInjector, tokenOrType: any): IInjector;
+
+    /**
      * Gets a scoped injector using the Id or the Name
      * @param nameOrId The name or the ID of the scope;
      * @description Will perform a breadth-first search

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -11,6 +11,16 @@ export type InjectionType = 'singleton' | 'multiple' | 'factory' | 'lazy' | 'opt
 
 export type Newable<T = any, T2 extends T = T> = new (...args: any[]) => T2;
 
+export type Constructor<T> = new (...args: any[]) => T;
+
+export type StaticTypes<T> = {
+    [K in keyof T]: Constructor<T[K]>;
+};
+
+export type MetadataParams<T> = T extends new (...args: infer P) => any ? P : never;
+
+export type MetadataStaticConstructorTypes<T> = StaticTypes<MetadataParams<T>>;
+
 export type NewableConstructorInterceptor = new (...args: any[]) => IConstructionInterceptor;
 
 // More forgiving InstanceType to support instances of an Abstract Type (not Newable)
@@ -354,7 +364,7 @@ export interface IInjectionConfiguration<T = any> {
     /**
      * You can provide explicit metadata for a type using this property.  Note if you are not leveraging decorators with 'emitDecoratorMetadata' you must provide all metadata for a given type
      */
-    metadata?: any[];
+    metadata?: MetadataStaticConstructorTypes<T>;
 }
 
 /**

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -343,6 +343,8 @@ export interface IInjectionConfiguration<T = any> {
      * @description If a type is provided the injector will attempt to substitute the original type with the new one being registered here.
      */
     resolution?: IExternalResolutionConfiguration<T> | T;
+
+    metadata?: any[];
 }
 
 /**

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -65,7 +65,7 @@ function findIndex<T>(data: Array<T>, predicate: (item: T) => boolean): number {
  */
 export interface IConstructionOptionsInternal<T extends Newable, TParams = Partial<ConstructorParameters<T>>>
     extends IConstructionOptions<T, TParams> {
-    mode?: 'standard' | 'optional' | 'factory';
+    mode?: 'standard' | 'optional';
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7910,9 +7910,9 @@
             }
         },
         "typescript": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
-            "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
+            "version": "3.4.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+            "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
             "dev": true
         },
         "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/needle",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7910,9 +7910,9 @@
             }
         },
         "typescript": {
-            "version": "3.4.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-            "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.7.tgz",
+            "integrity": "sha512-yi7M4y74SWvYbnazbn8/bmJmX4Zlej39ZOqwG/8dut/MYoSQ119GY9ZFbbGsD4PFZYWxqik/XsP3vk3+W5H3og==",
             "dev": true
         },
         "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
         "ts-loader": "^5.4.5",
         "tsconfig-paths-webpack-plugin": "^3.2.0",
         "typedoc": "^0.16.1",
-        "typescript": "~3.4.5",
+        "typescript": "^4.0.7",
         "webpack": "^4.39.2"
     },
     "peerDependencies": {
-        "typescript": ">=3.4"
+        "typescript": ">=4.0"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
         "ts-loader": "^5.4.5",
         "tsconfig-paths-webpack-plugin": "^3.2.0",
         "typedoc": "^0.16.1",
-        "typescript": "^4.0.7",
+        "typescript": "~3.4.5",
         "webpack": "^4.39.2"
     },
     "peerDependencies": {
-        "typescript": ">=4.0"
+        "typescript": ">=3.4"
     },
     "repository": {
         "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ import "reflect-metadata";
 
 ## Decorators vs Registration API
 
-This library performs runtime introspection in order to determine what types it should construct.  To do this the library uses metadata and generally this metadata will be implicitly captured for you if you have enabled TypeScripts `experimentalDecorators` and a class is decorated with any decorator. You do not need to manage it at all.  However, you do not need to use decorators if you do not wish to.  In the case where no decorators applied you will need to manually provider the metadata via the registration API.  **Note** Managing the metadata explicitly can be time consuming so we recommend using the auto generated metadata approach by default. 
+This library performs runtime introspection in order to determine what types it should construct.  To do this the library uses metadata and generally this metadata will be implicitly captured for you if you have enabled TypeScripts `experimentalDecorators` and a class is decorated with any decorator. However, you do not need to use decorators if you do not wish to.  In the case where no decorators are applied you will need to manually provide the metadata via the registration API.  **Note** Managing the metadata explicitly can be time consuming so we **recommend using the auto generated metadata approach by default**. 
 
 ## Creating an injectable type
 

--- a/readme.md
+++ b/readme.md
@@ -875,8 +875,3 @@ platformBrowserDynamic(providers)
     .bootstrapModule(AppModule)
     .catch(err => console.error(err));
 ```
-
-# Decorators vs API
-
-Using the decorators or using the API is really up to the developer.  As you can see you can achieve the same with both approaches.  However some advice when using the API. You may want to have a single registration file which registers all your injectables.  Avoid the urge to do this as it leads to issues when trying to implement semantic injection. Instead keep registrations local to the class implementations. 
-

--- a/readme.md
+++ b/readme.md
@@ -59,26 +59,39 @@ import "reflect-metadata";
 
 # Injectable basics
 
+## Decorators vs Registration API
+
+This library performs runtime introspection in order to determine what types it should construct.  To do this the library uses metadata and generally this metadata will be implicitly captured for you if you have enabled TypeScripts `experimentalDecorators` and a class is decorated with any decorator. You do not need to manage it at all.  However, you do not need to use decorators if you do not wish to.  In the case where no decorators applied you will need to manually provider the metadata via the registration API.  **Note** Managing the metadata explicitly can be time consuming so we recommend using the auto generated metadata approach by default. 
+
 ## Creating an injectable type
 
-The easiest way to make a type injectable is to annotate it with the @Injectable annotation.  All types by default decorated in this way will be available for injection in any runtime context. 
+The easiest way to make a type injectable is to decorate it with the @Injectable decorator.  All types by default decorated in this way will be available for injection in any runtime context. 
 
 ```typescript
 import { Injectable } from '@morgan-stanley/needle';
 
 @Injectable()
-class MyThing {}
+class Pet {}
+
+@Injectable()
+class Owner {
+    constructor(pet: Pet) {}
+}
 ```
 
-While annotations are recommended for most use cases, you can also achieve the same using the Injector API. You gain access to this API by importing the `getRootInjector` function. 
+While decorators are recommended, you can also achieve the same using the Injector API. You gain access to this API by importing the `getRootInjector` function. **IMPORTANT** If you have decided not to use decorators for you injectable types, you will need to provide the constructor metadata explicitly.  Below is an example of how you can do that. 
 
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
 
-class MyThing {}
+class Pet {}
 
-//Equivalent to annotation
-getRootInjector().register(MyThing)
+class Owner {
+    constructor(pet: Pet) {}
+}
+
+//Equivalent to decorator
+getRootInjector().register(Owner, { metadata: Pet }).register(Pet)
 ```
 
 ## Resolving injectables
@@ -88,7 +101,7 @@ In order to resolve an instance of your injectable you have a couple of options.
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
 
-const myThing = getRootInjector().get(MyThing);
+const myThing = getRootInjector().get(Owner);
 ```
 
 Alternatively, you can import the `get` function directly. 
@@ -96,7 +109,7 @@ Alternatively, you can import the `get` function directly.
 ```typescript
 import { get } from '@morgan-stanley/needle';
 
-const myThing = get(MyThing);
+const myThing = get(Owner);
 ```
 
 Both examples map to the same underlying implementation and use the root injector to resolve an instance.  Resolving the same type twice will result in the same instance being serviced from the cache.  
@@ -104,11 +117,13 @@ Both examples map to the same underlying implementation and use the root injecto
 ```typescript
 import { getRootInjector, get } from '@morgan-stanley/needle';
 
-const thing1 = getRootInjector().get(MyThing);
-const thing2 = get(MyThing);
+const owner1 = getRootInjector().get(Owner);
+const owner2 = get(Owner);
 
-console.log(thing1 === thing2) //True
+console.log(owner1 === owner2) //True
 ```
+
+All child dependencies (in this case `Pet`) will be automatically resolved for the `Owners` constructor.
 
 # Tokens
 
@@ -116,7 +131,7 @@ Tokens allow us to provide a marker to the injector whereby the type we are goin
 
 ## Registering with tokens
 
-The simplest way to register your type against a token is to use the tokens array defined in the `@Injectable` annotation. here we have a type `GeographyStudent` who defines a string `geography-student`  upon which this type can be resolved.  
+The simplest way to register your type against a token is to use the tokens array defined in the `@Injectable` decorator. here we have a type `GeographyStudent` who defines a string `geography-student`  upon which this type can be resolved.  
 
 ```typescript
 import { Injectable } from '@morgan-stanley/needle';
@@ -165,7 +180,7 @@ getRootInjector()
 
 ## Resolving by token
 
-To resolve a type by token we can make use of the `@Inject` annotation. In the constructor of a given injectable we can mark one of the parameters with `@Inject` providing a token which we wish to resolve. Note, the parameter type does not need to match the type of the injected value.  This is what allows us to use either interfaces or a sub type as a replacement for the real type. 
+To resolve a type by token we can make use of the `@Inject` decorator. In the constructor of a given injectable we can mark one of the parameters with `@Inject` providing a token which we wish to resolve. Note, the parameter type does not need to match the type of the injected value.  This is what allows us to use either interfaces or a sub type as a replacement for the real type. 
 
 ```typescript
 @Injectable()
@@ -264,7 +279,7 @@ getRootInjector()
 
 Strategies allow us to register multiple type providers against a given strategy key and then inject an array of all the strategies in the given consumer class. An injectable type can both exist as a strategy and pure injectable at the same time.  
 
-Creating strategies can be achieved using the `@Injectable` annotation or the API. Both approaches make use of the `strategy` property on the injectable config. 
+Creating strategies can be achieved using the `@Injectable` decorator or the API. Both approaches make use of the `strategy` property on the injectable config. 
 
 ## Registering strategies
 
@@ -316,7 +331,7 @@ getRootInjector()
 ```
 ## Resolving strategies
 
-When it comes to injecting lists of strategies we can use the `@Strategy` annotation to mark that we expect an array of strategies.  You can register consumers of strategies using this annotation or the API.  
+When it comes to injecting lists of strategies we can use the `@Strategy` decorator to mark that we expect an array of strategies.  You can register consumers of strategies using this decorator or the API.  
 
 ```typescript
 import { Injectable, get } from '@morgan-stanley/needle';
@@ -351,7 +366,7 @@ All types registered with the container can be used as factories.  There is no s
 
 ## Resolve a Factory
 
-There are two ways to resolve a factory.  Explicitly using the API or via the `@Factory` annotation.  Below are examples of both types of resolution.  
+There are two ways to resolve a factory.  Explicitly using the API or via the `@Factory` decorator.  Below are examples of both types of resolution.  
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
 
@@ -360,7 +375,7 @@ const carFactory = getRootInjector().getFactory(Car)
 console.log(carFactory) // Defined
 ```
 
-Example of annotation. 
+Example of decorator. 
 
 ```typescript
 @Injectable()
@@ -416,7 +431,7 @@ All types registered with the container can be used with lazy injection.  There 
 
 ## Resolve a LazyInstance
 
-There are two ways to resolve a Lazy.  Explicitly using the API or via the `@Lazy` annotation.  Below are examples of both types of resolution.  
+There are two ways to resolve a Lazy.  Explicitly using the API or via the `@Lazy` decorator.  Below are examples of both types of resolution.  
 
 ```typescript
 import { getRootInjector } from '@morgan-stanley/needle';
@@ -440,7 +455,7 @@ const carInstance = carLazy.value;
 hasValue = carLazy.hasValue //True;
 ```
 
-We can use the `@Lazy` annotation to signal to the injector that we would like a lazy to be provided in place of the real injectable.  
+We can use the `@Lazy` decorator to signal to the injector that we would like a lazy to be provided in place of the real injectable.  
 
 ```typescript
 @Injectable()
@@ -451,7 +466,7 @@ class CarManufacturer {
 
 # Optional injection
 
-In some environments it will not always be the case that an injectable type has been registered with the injector.  For these scenarios you can leverage the `@Optional` annotation which will allow the injector to resolve `undefined` if no matching registration can be found. 
+In some environments it will not always be the case that an injectable type has been registered with the injector.  For these scenarios you can leverage the `@Optional` decorator which will allow the injector to resolve `undefined` if no matching registration can be found. 
 
 ## Registering an Optional Injectable
 
@@ -459,7 +474,7 @@ All constructor types can be used with optional injection.  There is no special 
 
 ## Resolve an optional injectable
 
-We can use the `@Optional` annotation to signal to the injector that we would like it to resolve `undefined` if no registrations can be found. Below is an example of a constructor for a Car type which supports optional storage.  
+We can use the `@Optional` decorator to signal to the injector that we would like it to resolve `undefined` if no registrations can be found. Below is an example of a constructor for a Car type which supports optional storage.  
 
 ```typescript
 @Injectable()
@@ -499,7 +514,7 @@ There are times where you may require more granular control of a specific types 
 
 ## Registering a type for external resolution
 
-If you want to entirely own the process of constructing a given type you can define an `ExternalResolutionStrategy` which will be used in place of needles construction logic.  Below shows an example of registering our own resolution strategy against a given type using the annotation approach.  The `resolution` takes a resolver function where you can perform your custom construction and an additional flag (`cacheSyncing`) signalling to needle if it should store the result in its internal cache. 
+If you want to entirely own the process of constructing a given type you can define an `ExternalResolutionStrategy` which will be used in place of needles construction logic.  Below shows an example of registering our own resolution strategy against a given type using the decorator approach.  The `resolution` takes a resolver function where you can perform your custom construction and an additional flag (`cacheSyncing`) signalling to needle if it should store the result in its internal cache. 
 
 ```typescript
 @Injectable({
@@ -861,7 +876,7 @@ platformBrowserDynamic(providers)
     .catch(err => console.error(err));
 ```
 
-# Annotations vs API
+# Decorators vs API
 
-Using the annotations or using the API is really up to the developer.  As you can see you can achieve the same with both approaches.  However some advice when using the API. You may want to have a single registration file which registers all your injectables.  Avoid the urge to do this as it leads to issues when trying to implement semantic injection. Instead keep registrations local to the class implementations. 
+Using the decorators or using the API is really up to the developer.  As you can see you can achieve the same with both approaches.  However some advice when using the API. You may want to have a single registration file which registers all your injectables.  Avoid the urge to do this as it leads to issues when trying to implement semantic injection. Instead keep registrations local to the class implementations. 
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -36,6 +36,15 @@ export abstract class Student extends Individual {}
 
 interface IStrategy {}
 
+//no metadata test
+export class Pet {
+    public animalType = 'unknown';
+}
+//no metadata test
+export class Owner {
+    constructor(public pet: Pet) {}
+}
+
 @Injectable({
     strategy: 'work-strategies',
 })
@@ -280,6 +289,18 @@ describe('Injector', () => {
     });
 
     describe('Registration', () => {
+        it('should register using explicit metadata', () => {
+            const instance = getInstance();
+
+            const owner = instance
+                .register(Owner, { metadata: [Pet] })
+                .register(Pet)
+                .get(Owner);
+
+            expect(owner).toBeDefined();
+            expect(owner.pet).toBeDefined();
+        });
+
         it('should register a type for injection', () => {
             const instance = getInstance();
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -37,12 +37,21 @@ export abstract class Student extends Individual {}
 interface IStrategy {}
 
 //no metadata test
-export class Pet {
+abstract class Pet {
     public animalType = 'unknown';
 }
+
+class Dog extends Pet {
+    public animalType = 'Dog';
+}
+
+class Cat extends Pet {
+    public animalType = 'Cat';
+}
+
 //no metadata test
-export class Owner {
-    constructor(public pet: Pet) {}
+class Owner {
+    constructor(public dog: Dog, public cat: Cat) {}
 }
 
 @Injectable({
@@ -289,18 +298,6 @@ describe('Injector', () => {
     });
 
     describe('Registration', () => {
-        it('should register using explicit metadata', () => {
-            const instance = getInstance();
-
-            const owner = instance
-                .register(Owner, { metadata: [Pet] })
-                .register(Pet)
-                .get(Owner);
-
-            expect(owner).toBeDefined();
-            expect(owner.pet).toBeDefined();
-        });
-
         it('should register a type for injection', () => {
             const instance = getInstance();
 
@@ -1056,6 +1053,34 @@ describe('Injector', () => {
             expect(exception.message).toBe(
                 `Cannot construct Type 'Child' with ancestry 'Child' the type is either not decorated with @Injectable or injector.register was not called for the type or the constructor param is not marked @Optional`,
             );
+        });
+
+        it('should resolve a type that is using explicit metadata', () => {
+            const instance = getInstance();
+
+            const owner = instance
+                .register(Owner, { metadata: [Dog, Cat] })
+                .register(Dog)
+                .register(Cat)
+                .get(Owner);
+
+            expect(owner).toBeDefined();
+            expect(owner.dog).toBeDefined();
+            expect(owner.cat).toBeDefined();
+        });
+
+        it('should return undefined for deps', () => {
+            const instance = getInstance();
+
+            const owner = instance
+                .register(Owner)
+                .register(Dog)
+                .register(Cat)
+                .get(Owner);
+
+            expect(owner).toBeDefined();
+            expect(owner.dog).toBeUndefined();
+            expect(owner.cat).toBeUndefined();
         });
 
         it('should service subsequent instances of a type from the cache', () => {

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -22,6 +22,7 @@ import {
     LazyInstance,
     Optional,
     Strategy,
+    MetadataParams,
 } from '../main';
 import { DI_ROOT_INJECTOR_KEY, NULL_VALUE, TYPE_NOT_FOUND, UNDEFINED_VALUE } from '../main/constants/constants';
 import { InstanceCache } from '../main/core/cache';
@@ -47,6 +48,7 @@ class Dog extends Pet {
 
 class Cat extends Pet {
     public animalType = 'Cat';
+    public breed = 'Ginger';
 }
 
 //no metadata test

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -1480,6 +1480,24 @@ describe('Injector', () => {
 
         describe('Ancestry', () => {
             describe('Resolution', () => {
+                describe('Resolve instance from ancestor with explicit metadata', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`Should resolve using ancestors registration - ${getTestInfoAsText(test)}`, () => {
+                            const instance = getInstance(true, test.depth);
+
+                            instance
+                                .getScope(`level-${test.registrationLevel}`)!
+                                .register(Owner, { metadata: [Dog, Cat] })
+                                .register(Dog)
+                                .register(Cat);
+
+                            const owner = instance.getScope(`level-${test.resolutionLevel}`)!.get(Owner);
+
+                            expect(owner).toBeDefined();
+                        });
+                    });
+                });
+
                 describe('Resolve instance from ancestor', () => {
                     generateTestExecutionData().forEach(test => {
                         it(`Should resolve using ancestors registration - ${getTestInfoAsText(test)}`, () => {

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -689,6 +689,23 @@ describe('Injector', () => {
             expect(vehicle.type).toBe('Bike');
         });
 
+        it('should throw excception when factory type is not registered and attempt to resolve.', () => {
+            const instance = getInstance();
+            let registrationError: any;
+            const factory = instance.getFactory(Vehicle);
+
+            try {
+                factory.create('Bike');
+            } catch (ex) {
+                registrationError = ex;
+            }
+
+            expect(registrationError).toBeDefined();
+            expect(registrationError.message).toBe(
+                "Cannot construct Type 'Vehicle' with ancestry '' the type is either not decorated with @Injectable or injector.register was not called for the type or the constructor param is not marked @Optional",
+            );
+        });
+
         it('should auto resolve parameters for a factory when not supplied by developer', () => {
             const instance = getInstance();
 


### PR DESCRIPTION
This PR adds support for registering types without the need of decorators.  Previously you did not need to user our @Injectable decorator just any, but now a developer can choose to specify this explicitly.  