### PR TITLE
Support intrinsic type injection directly into injectable type constructors

### DIFF
--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -1,5 +1,6 @@
 export const DI_ROOT_INJECTOR_KEY = 'needle.morganstanley.com.root.injector';
 export const INJECTOR_TYPE_ID = '5495541b-7416-42a6-a830-065fe591591a';
+export const BOXED_TYPE_ID = '5594b0f3-33d2-427a-bada-828e16720436';
 
 /**
  * Represents a null value to the injector so it can discriminate against null

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -385,9 +385,9 @@ export interface IValueInjectionConfiguration<T extends ValueType> {
     tokens: Array<StringOrSymbol> | undefined;
 
     /**
-     * Value resolution strategy.  Can be either a raw value or an external value resolution config
+     * The value or the value resolution strategy.
      */
-    resolution: IExternalValueResolutionConfiguration<T> | T;
+    value: IExternalValueResolutionConfiguration<T> | T;
 }
 
 /**

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -2,7 +2,7 @@ import { AutoFactory } from '../core/factory';
 import { LazyInstance } from '../core/lazy';
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export type ValueType = number | string | Date | boolean | Function;
+export type ValueType = number | string | Date | boolean | Function | RegExp | Error | Array<any> | Object;
 
 export type InjectorIdentifier = string;
 

--- a/main/contracts/contracts.ts
+++ b/main/contracts/contracts.ts
@@ -1,6 +1,9 @@
 import { AutoFactory } from '../core/factory';
 import { LazyInstance } from '../core/lazy';
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type ValueType = number | string | Date | boolean | Function;
+
 export type InjectorIdentifier = string;
 
 export type StringOrSymbol = string | symbol;
@@ -214,9 +217,9 @@ export interface IInjector {
     register<T>(type: T, config?: IInjectionConfiguration<T>): this;
 
     /**
-     * Get the list of registration
+     * Registers a value with the injector.
      */
-    getRegistrations(): Map<any, IInjectionConfiguration>;
+    registerValue<T extends ValueType>(configuration: IValueInjectionConfiguration<T>): this;
 
     /**
      * Registers and instance of a type in the container
@@ -267,6 +270,11 @@ export interface IInjector {
      * @param parent Optional, destroy can be triggered by a parent being destroyed.
      */
     destroy(parent?: IInjector): void;
+
+    /**
+     * Get the list of registration
+     */
+    getRegistrations(): Map<any, IInjectionConfiguration>;
 
     /**
      * Gets an AutoFactory for a given type
@@ -368,18 +376,58 @@ export interface IInjectionConfiguration<T = any> {
 }
 
 /**
- * Configuration interface used when defining external resolution strategy
+ * Injection configuration object used for profiling information and behavior about the injectable value to the injector
  */
-export interface IExternalResolutionConfiguration<T = any> {
+export interface IValueInjectionConfiguration<T extends ValueType> {
+    /**
+     * A list of tokens that this injectable can be resolved by using the @Inject("token") annotation
+     */
+    tokens: Array<StringOrSymbol> | undefined;
+
+    /**
+     * Value resolution strategy.  Can be either a raw value or an external value resolution config
+     */
+    resolution: IExternalValueResolutionConfiguration<T> | T;
+}
+
+/**
+ * Represents a Boxed value type.
+ */
+export interface IBoxedValue {
+    typeId: string;
+    unbox(): any;
+}
+
+/**
+ * Base interface used when defining external resolution strategy
+ */
+export interface IExternalResolutionConfigurationBase {
     /**
      * Flag that when set to true will sync instances with the injectors cache.
      * @description By default no cache syncing is done
      */
     cacheSyncing?: boolean;
+}
+
+/**
+ * Configuration interface used when defining external resolution strategy
+ */
+export interface IExternalResolutionConfiguration<T = any> extends IExternalResolutionConfigurationBase {
     /**
      * The resolver function to be used when instancing types
      */
     resolver(type: T, currentInjector: IInjector, locals?: any): InstanceOfType<T>;
+}
+
+/**
+ * Configuration interface used when defining external value resolution strategy
+ */
+export interface IExternalValueResolutionConfiguration<T extends ValueType = any>
+    extends IExternalResolutionConfigurationBase {
+    /**
+     * The resolver function to be used when resolving the value
+     */
+    resolver(currentInjector: IInjector): T;
 }
 
 /**

--- a/main/core/boxing.ts
+++ b/main/core/boxing.ts
@@ -1,0 +1,31 @@
+import { isExternalValueResolutionConfigurationLike } from './guards';
+import { IInjector, IBoxedValue } from '../contracts/contracts';
+import { BOXED_TYPE_ID } from '../constants/constants';
+
+export function createBoxedValueType() {
+    const Type = class implements IBoxedValue {
+        public typeId = BOXED_TYPE_ID;
+        public value: any;
+
+        constructor(public injector: IInjector, public readonly resolver: any) {}
+
+        public unbox(): any {
+            if (this.value == null) {
+                if (isExternalValueResolutionConfigurationLike(this.resolver)) {
+                    const value = this.resolver.resolver(this.injector);
+                    if (this.resolver.cacheSyncing) {
+                        this.value = value;
+                    } else {
+                        return value;
+                    }
+                } else {
+                    this.value = this.resolver;
+                }
+            }
+
+            return this.value;
+        }
+    };
+
+    return Type;
+}

--- a/main/core/guards.ts
+++ b/main/core/guards.ts
@@ -6,7 +6,10 @@ import {
     ILazyParameterInjectionToken,
     IParameterInjectionToken,
     StringOrSymbol,
+    IExternalValueResolutionConfiguration,
+    IBoxedValue,
 } from '../contracts/contracts';
+import { BOXED_TYPE_ID } from '../constants/constants';
 
 /**
  * Determines if the given type is an IInjectionTokenParameter
@@ -50,10 +53,18 @@ export function isStringOrSymbol(item: any): item is StringOrSymbol {
 }
 
 /**
- * Determines if a given value is an external resolution config
+ * Determines if the given value is an external resolution config
  * @param item
  */
 export function isExternalResolutionConfigurationLike(item: any): item is IExternalResolutionConfiguration {
+    return typeof item != null && item.resolver != null && typeof item.resolver === 'function';
+}
+
+/**
+ * Determines if the given value is an external value resolution config
+ * @param item
+ */
+export function isExternalValueResolutionConfigurationLike(item: any): item is IExternalValueResolutionConfiguration {
     return typeof item != null && item.resolver != null && typeof item.resolver === 'function';
 }
 
@@ -71,4 +82,11 @@ export function isInjectorLike(thing: any): thing is IInjector {
         thing.register != null &&
         thing.registerParamForFactoryInjection != null
     );
+}
+
+/**
+ * Determines if a value is a Boxed value
+ */
+export function isBoxedValue(thing: any): thing is IBoxedValue {
+    return thing != null && thing.typeId === BOXED_TYPE_ID;
 }

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -182,7 +182,7 @@ export class Injector implements IInjector {
 
         // Create a boxed value type, then an instance of it.
         const BoxedValue = createBoxedValueType();
-        const boxedValueInstance = new BoxedValue(this, configuration.resolution);
+        const boxedValueInstance = new BoxedValue(this, configuration.value);
 
         //Now we can just register this type and its instance with the standard injector register method
         this.registerInstance(BoxedValue, boxedValueInstance, configuration);

--- a/readme.md
+++ b/readme.md
@@ -563,6 +563,53 @@ getRootInjector().register(Car, { resolution: SuperCar });
 
 In the section under **Global Configuration** you can learn about how you can use **External Resolution Strategies** to delegate construction globally and provide fallback strategies when performing interop with other container systems. 
 
+# Register Value
+
+JavaScript has a number of intrinsic types that you may wish to injector directly into a constructor without the need for wrapping in a higher type. These types include `Array`, `Boolean`, `Date`, `Error`, `Function`, `JSON`, `Number`, `RegExp` and `String`. In order to support direct injection of these types we can use the `registerValue` method found on the injector.  The `registerValue` method only takes one parameter, the injection configuration object. There are two ways to resolve the value, you can either provide a value at point of registration or you can use a resolution strategy to resolve at point of use.  Below are some examples to illustrate how this works. 
+
+## Registering with a AOT value
+
+```typescript
+@Injectable()
+class SecurityContext  {
+    constructor(@Inject('security-token') public securityToken: string){}
+}
+
+// Tokens are used the same as for other types. 
+getRootInjector().registerValue<string>({
+    tokens: ['security-token'], 
+    value: 'TmVlZGxlIFByb2plY3Q=',
+});
+```
+
+## Registering with a JIT computed value value
+
+```typescript
+getRootInjector().registerValue<string>({
+    tokens: ['security-token'], 
+    value: {
+        cacheSyncing: true,
+        resolver: _injector => Encryption.resolveUserContextToken(),
+    },
+});
+```
+
+If you want the value to mutate on each request, you can set `cacheSyncing` to false.  
+
+**Note**: As values have no associated type upon which to decorate, you can only use the Injector API to register values.  
+
+```typescript
+import { getRootInjector } from '@morgan-stanley/needle';
+
+const vehicle =  new Vehicle('Bike');
+
+getRootInjector().registerInstance(Vehicle, vehicle);
+
+const instance = get(Vehicle); 
+
+console.log(instance === vehicle) // True
+```
+
 # Metrics tracking
 
 The injector tracks metrics about your injectable types during runtime.  There are a range of different values captured and these are stored in the metrics provider which is accessible via the Injector type.  The data is store as records and the below type shows the information captured.  

--- a/readme.md
+++ b/readme.md
@@ -565,7 +565,7 @@ In the section under **Global Configuration** you can learn about how you can us
 
 # Register Value
 
-JavaScript has a number of intrinsic types that you may wish to injector directly into a constructor without the need for wrapping in a higher type. These types include `Array`, `Boolean`, `Date`, `Error`, `Function`, `JSON`, `Number`, `RegExp` and `String`. In order to support direct injection of these types we can use the `registerValue` method found on the injector.  The `registerValue` method only takes one parameter, the injection configuration object. There are two ways to resolve the value, you can either provide a value at point of registration or you can use a resolution strategy to resolve at point of use.  Below are some examples to illustrate how this works. 
+JavaScript has a number of intrinsic types that you may wish to inject directly into a constructor without the need for wrapping in a higher type. These types include `Array`, `Boolean`, `Date`, `Error`, `Function`, `JSON`, `Number`, `RegExp` and `String`. In order to support direct injection of these types we can use the `registerValue` method found on the injector.  The `registerValue` method only takes one parameter, the injection configuration object. There are two ways to resolve the value, you can either provide a value at point of registration or you can use a resolution strategy to resolve at point of use.  Below are some examples to illustrate how this works. 
 
 ## Registering with a AOT value
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -509,7 +509,7 @@ describe('Injector', () => {
             try {
                 instance.registerValue<string>({
                     tokens: [],
-                    resolution: 'myvalue',
+                    value: 'myvalue',
                 });
             } catch (ex) {
                 error = ex;
@@ -524,7 +524,7 @@ describe('Injector', () => {
 
             instance.registerValue<string>({
                 tokens: ['mystring'],
-                resolution: 'myvalue',
+                value: 'myvalue',
             });
 
             const value = instance.get('mystring');
@@ -538,7 +538,7 @@ describe('Injector', () => {
 
             instance.registerValue<number>({
                 tokens: ['answer-to-everything'],
-                resolution: 42,
+                value: 42,
             });
 
             const value = instance.get<number>('answer-to-everything');
@@ -552,7 +552,7 @@ describe('Injector', () => {
 
             instance.registerValue<Date>({
                 tokens: ['battle-of-hastings'],
-                resolution: new Date('14 Oct 1066'),
+                value: new Date('14 Oct 1066'),
             });
 
             const value = instance.get<Date>('battle-of-hastings');
@@ -571,7 +571,7 @@ describe('Injector', () => {
             // eslint-disable-next-line @typescript-eslint/ban-types
             instance.registerValue<Function>({
                 tokens: ['my-func'],
-                resolution: () => (invoked = true),
+                value: () => (invoked = true),
             });
 
             // eslint-disable-next-line @typescript-eslint/ban-types
@@ -587,7 +587,7 @@ describe('Injector', () => {
 
             instance.registerValue<boolean>({
                 tokens: ['flag'],
-                resolution: true,
+                value: true,
             });
 
             const value = instance.get<boolean>('flag');
@@ -600,7 +600,7 @@ describe('Injector', () => {
 
             instance.registerValue<string>({
                 tokens: ['value-1'],
-                resolution: {
+                value: {
                     cacheSyncing: true,
                     resolver: _injector => 'my-test',
                 },
@@ -618,7 +618,7 @@ describe('Injector', () => {
 
             instance.registerValue<number>({
                 tokens: ['value-1'],
-                resolution: {
+                value: {
                     cacheSyncing: false,
                     resolver: _injector => ++counter,
                 },
@@ -638,17 +638,17 @@ describe('Injector', () => {
 
             instance.registerValue<boolean>({
                 tokens: ['value-1'],
-                resolution: true,
+                value: true,
             });
 
             instance.registerValue<string>({
                 tokens: ['value-2'],
-                resolution: 'my-test',
+                value: 'my-test',
             });
 
             instance.registerValue<number>({
                 tokens: ['value-3'],
-                resolution: 13,
+                value: 13,
             });
 
             const value1 = instance.get<boolean>('value-1');
@@ -668,7 +668,7 @@ describe('Injector', () => {
                 .registerParamForTokenInjection('raw-token', SecurityToken, 0)
                 .registerValue<string>({
                     tokens: ['raw-token'],
-                    resolution: 'ABDCEF-12345',
+                    value: 'ABDCEF-12345',
                 });
 
             const securityToken = instance.get(SecurityToken);
@@ -683,13 +683,13 @@ describe('Injector', () => {
 
             instance.registerValue<string>({
                 tokens: ['my-value'],
-                resolution: 'my-test-value',
+                value: 'my-test-value',
             });
 
             try {
                 instance.registerValue<string>({
                     tokens: ['my-value'],
-                    resolution: 'another value',
+                    value: 'another value',
                 });
             } catch (ex) {
                 error = ex;
@@ -1759,7 +1759,7 @@ describe('Injector', () => {
 
                             instance.getScope(`level-${test.registrationLevel}`)!.registerValue<string>({
                                 tokens: ['ancestor-token'],
-                                resolution: 'ancestor',
+                                value: 'ancestor',
                             });
 
                             const ancestorValue = instance
@@ -1984,7 +1984,7 @@ describe('Injector', () => {
                                 .getScope(`level-${test.registrationLevel}`)!
                                 .registerValue<string>({
                                     tokens: ['my-value'],
-                                    resolution: 'value-parent',
+                                    value: 'value-parent',
                                 });
 
                             const value1 = ancestralInjector.get('my-value');
@@ -1992,7 +1992,7 @@ describe('Injector', () => {
 
                             scoped.registerValue<string>({
                                 tokens: ['my-value'],
-                                resolution: 'value-child',
+                                value: 'value-child',
                             });
 
                             const value2 = scoped.get('my-value');

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -120,6 +120,11 @@ class NaughtyTurtle {
 }
 
 @Injectable()
+class SecurityToken {
+    constructor(@Inject('raw-token') public rawToken: string) {}
+}
+
+@Injectable()
 class Vehicle {
     constructor(public type: 'Bike' | 'Car' | 'Bus' | 'Train') {}
 }
@@ -492,6 +497,207 @@ describe('Injector', () => {
             expect(exception).toBeDefined();
             expect(exception.message).toBe(
                 `Cannot resolve Type with token 'unknownChild' as no types have been registered against that token value`,
+            );
+        });
+    });
+
+    describe('Values', () => {
+        it('should throw and error if no tokens provided', () => {
+            const instance = getInstance();
+            let error: any;
+
+            try {
+                instance.registerValue<string>({
+                    tokens: [],
+                    resolution: 'myvalue',
+                });
+            } catch (ex) {
+                error = ex;
+            }
+
+            expect(error).toBeDefined();
+            expect(error.message).toBe('All values must be registered with a given token');
+        });
+
+        it('should register and resolve the value of type [String]', () => {
+            const instance = getInstance();
+
+            instance.registerValue<string>({
+                tokens: ['mystring'],
+                resolution: 'myvalue',
+            });
+
+            const value = instance.get('mystring');
+
+            expect(value).toBeDefined();
+            expect(value).toBe('myvalue');
+        });
+
+        it('should register and resolve the value of type [Number]', () => {
+            const instance = getInstance();
+
+            instance.registerValue<number>({
+                tokens: ['answer-to-everything'],
+                resolution: 42,
+            });
+
+            const value = instance.get<number>('answer-to-everything');
+
+            expect(value).toBeDefined();
+            expect(value).toBe(42);
+        });
+
+        it('should register and resolve the value of type [Date]', () => {
+            const instance = getInstance();
+
+            instance.registerValue<Date>({
+                tokens: ['battle-of-hastings'],
+                resolution: new Date('14 Oct 1066'),
+            });
+
+            const value = instance.get<Date>('battle-of-hastings');
+
+            expect(value).toBeDefined();
+            expect(value.getDate()).toBe(14);
+            expect(value.getMonth()).toBe(9);
+            expect(value.getFullYear()).toBe(1066);
+        });
+
+        it('should register and resolve the value of type [Function]', () => {
+            const instance = getInstance();
+
+            let invoked = false;
+
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            instance.registerValue<Function>({
+                tokens: ['my-func'],
+                resolution: () => (invoked = true),
+            });
+
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            const value = instance.get<Function>('my-func');
+            value();
+
+            expect(typeof value === 'function').toBeTrue();
+            expect(invoked).toBeTrue();
+        });
+
+        it('should register and resolve the value of type [Boolean]', () => {
+            const instance = getInstance();
+
+            instance.registerValue<boolean>({
+                tokens: ['flag'],
+                resolution: true,
+            });
+
+            const value = instance.get<boolean>('flag');
+
+            expect(value).toBeTrue();
+        });
+
+        it('should use the resolver config if provided to resolve the value', () => {
+            const instance = getInstance();
+
+            instance.registerValue<string>({
+                tokens: ['value-1'],
+                resolution: {
+                    cacheSyncing: true,
+                    resolver: _injector => 'my-test',
+                },
+            });
+
+            const value = instance.get<string>('value-1');
+
+            expect(value).toBe('my-test');
+        });
+
+        it('should regenerate the value if the resolver config does not enable caching', () => {
+            const instance = getInstance();
+
+            let counter = 0;
+
+            instance.registerValue<number>({
+                tokens: ['value-1'],
+                resolution: {
+                    cacheSyncing: false,
+                    resolver: _injector => ++counter,
+                },
+            });
+
+            const value1 = instance.get<number>('value-1');
+            const value2 = instance.get<number>('value-1');
+            const value3 = instance.get<number>('value-1');
+
+            expect(value1).toBe(1);
+            expect(value2).toBe(2);
+            expect(value3).toBe(3);
+        });
+
+        it('should register multiple values and resolve each without issue', () => {
+            const instance = getInstance();
+
+            instance.registerValue<boolean>({
+                tokens: ['value-1'],
+                resolution: true,
+            });
+
+            instance.registerValue<string>({
+                tokens: ['value-2'],
+                resolution: 'my-test',
+            });
+
+            instance.registerValue<number>({
+                tokens: ['value-3'],
+                resolution: 13,
+            });
+
+            const value1 = instance.get<boolean>('value-1');
+            const value2 = instance.get<string>('value-2');
+            const value3 = instance.get<number>('value-3');
+
+            expect(value1).toBe(true);
+            expect(value2).toBe('my-test');
+            expect(value3).toBe(13);
+        });
+
+        it('should inject the value into parent type', () => {
+            const instance = getInstance();
+
+            instance
+                .register(SecurityToken)
+                .registerParamForTokenInjection('raw-token', SecurityToken, 0)
+                .registerValue<string>({
+                    tokens: ['raw-token'],
+                    resolution: 'ABDCEF-12345',
+                });
+
+            const securityToken = instance.get(SecurityToken);
+
+            expect(securityToken).toBeDefined();
+            expect(securityToken.rawToken).toBe('ABDCEF-12345');
+        });
+
+        it('should throw an error if value registered twice under same token and allowDuplicateTokens not enabled', () => {
+            const instance = getInstance();
+            let error: any;
+
+            instance.registerValue<string>({
+                tokens: ['my-value'],
+                resolution: 'my-test-value',
+            });
+
+            try {
+                instance.registerValue<string>({
+                    tokens: ['my-value'],
+                    resolution: 'another value',
+                });
+            } catch (ex) {
+                error = ex;
+            }
+
+            expect(error).toBeDefined();
+            expect(error.message).toBe(
+                `Cannot register Type [class_1] with token 'my-value'. Duplicate token found for the following type [class_1]`,
             );
         });
     });
@@ -1546,6 +1752,26 @@ describe('Injector', () => {
                     });
                 });
 
+                describe('Resolve value from ancestor using token', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`Should resolve value using ancestors registration - ${getTestInfoAsText(test)}`, () => {
+                            const instance = getInstance(true, test.depth);
+
+                            instance.getScope(`level-${test.registrationLevel}`)!.registerValue<string>({
+                                tokens: ['ancestor-token'],
+                                resolution: 'ancestor',
+                            });
+
+                            const ancestorValue = instance
+                                .getScope(`level-${test.resolutionLevel}`)!
+                                .get('ancestor-token');
+
+                            expect(ancestorValue).toBeDefined();
+                            expect(ancestorValue).toBe('ancestor');
+                        });
+                    });
+                });
+
                 describe('Resolve strategy from ancestor', () => {
                     generateTestExecutionData().forEach(test => {
                         it(`Should resolve strategies using ancestors registration - ${getTestInfoAsText(
@@ -1725,7 +1951,7 @@ describe('Injector', () => {
             });
 
             describe('Overriding', () => {
-                describe('with register.instance() override in a scope', () => {
+                describe('with registerInstance() override in a scope', () => {
                     generateTestExecutionData().forEach(test => {
                         it(`should resolve the instance from the local scope ignoring the instance already resolved in parent scopes - ${getTestInfoAsText(
                             test,
@@ -1743,6 +1969,35 @@ describe('Injector', () => {
                             const scopedChild = scoped.get(Child);
 
                             expect(child === scopedChild).toBeFalsy();
+                        });
+                    });
+                });
+
+                describe('with registerValue() override in a scope', () => {
+                    generateTestExecutionData().forEach(test => {
+                        it(`should resolve the value from the local scope ignoring the value already resolved in parent scopes - ${getTestInfoAsText(
+                            test,
+                        )}`, () => {
+                            const instance = getInstance(true, test.depth);
+
+                            const ancestralInjector = instance
+                                .getScope(`level-${test.registrationLevel}`)!
+                                .registerValue<string>({
+                                    tokens: ['my-value'],
+                                    resolution: 'value-parent',
+                                });
+
+                            const value1 = ancestralInjector.get('my-value');
+                            const scoped = instance.getScope(`level-${test.resolutionLevel}`)!;
+
+                            scoped.registerValue<string>({
+                                tokens: ['my-value'],
+                                resolution: 'value-child',
+                            });
+
+                            const value2 = scoped.get('my-value');
+
+                            expect(value1 === value2).toBeFalsy();
                         });
                     });
                 });


### PR DESCRIPTION
This PR adds support for direct injection of intrinsic types into an injectables constructor.  There is support for AOT values as well as JIT values.  Further there is also support for recomputing values on each resolution.   There is also support for overriding these value registrations in scoped injectors.  (Covered in tests) 

```typescript
@Injectable()
class SecurityContext  {
    constructor(@Inject('security-token') public securityToken: string){}
}

// Tokens are used the same as for other types. 
getRootInjector().registerValue<string>({
    tokens: ['security-token'], 
    value: 'TmVlZGxlIFByb2plY3Q=',
});

getRootInjector().registerValue<string>({
    tokens: ['security-token'], 
    value: {
        cacheSyncing: true,
        resolver: _injector => Encryption.resolveUserContextToken(),
    },
});
```