### PR TITLE
Add support for named constant when auto resolving params.

### DIFF
--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -16,3 +16,8 @@ export const UNDEFINED_VALUE = { type: 'UNDEFINED_VALUE' };
  * Represents a type not being found inside of the injector or external injector
  */
 export const TYPE_NOT_FOUND = { type: 'TYPE_NOT_FOUND' };
+
+/**
+ * This constant can be used in conjunction with AutoFactory
+ */
+export const AUTO_RESOLVE = undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@morgan-stanley/needle",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.7",
+    "version": "0.3.8",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -481,7 +481,7 @@ const carWithSuperPowerfulEngine = factory.create(new SuperPowerfulEngine());
 
 ```
 
-If you prefer not to pass undefined to the factory, there is also a convenience named constant `AUTO_RESOLVE` which be used instead.  
+If you prefer not to pass undefined to the factory, there is also a named constant `AUTO_RESOLVE` which can be used instead.  
 
 ```typescript
 factory.create(AUTO_RESOLVE, 4);

--- a/readme.md
+++ b/readme.md
@@ -481,7 +481,13 @@ const carWithSuperPowerfulEngine = factory.create(new SuperPowerfulEngine());
 
 ```
 
-If you would **not** like the injector to auto resolve the value for engine and you wanted to actually return `null` or `undefined` you can use well known injector values to achieve this.  
+If you prefer not to pass undefined to the factory, there is also a convenience named constant `AUTO_RESOLVE` which be used instead.  
+
+```typescript
+factory.create(AUTO_RESOLVE, 4);
+```
+
+If you would **not** like the injector to auto resolve the value for engine and you wanted to actually return `null` or `undefined` you can use well known injector values (`UNDEFINED_VALUE`, `NULL_VALUE` ) to achieve this.  
 
 ```typescript
 

--- a/spec/injection.spec.ts
+++ b/spec/injection.spec.ts
@@ -23,7 +23,13 @@ import {
     Optional,
     Strategy,
 } from '../main';
-import { DI_ROOT_INJECTOR_KEY, NULL_VALUE, TYPE_NOT_FOUND, UNDEFINED_VALUE } from '../main/constants/constants';
+import {
+    DI_ROOT_INJECTOR_KEY,
+    NULL_VALUE,
+    TYPE_NOT_FOUND,
+    UNDEFINED_VALUE,
+    AUTO_RESOLVE,
+} from '../main/constants/constants';
 import { InstanceCache } from '../main/core/cache';
 import { isInjectorLike } from '../main/core/guards';
 import { InjectionTokensCache } from '../main/core/tokens';
@@ -1023,6 +1029,19 @@ describe('Injector', () => {
 
             const carFactory = instance.getFactory(Car);
             const car = carFactory.create();
+
+            expect(carFactory).toBeDefined();
+            expect(car).toBeDefined();
+            expect(car.engine).toBeDefined();
+        });
+
+        it('should auto resolve parameters for a factory when supplied using named constant', () => {
+            const instance = getInstance();
+
+            instance.register(Car).register(Engine);
+
+            const carFactory = instance.getFactory(Car);
+            const car = carFactory.create(AUTO_RESOLVE);
 
             expect(carFactory).toBeDefined();
             expect(car).toBeDefined();


### PR DESCRIPTION
```typescript
factory.create(AUTO_RESOLVE, 4);
```
instead of 
```typescript
factory.create(undefined, 4);
```