### PR TITLE
Simplify release action

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,8 +1,6 @@
 name: Create Release
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -27,17 +25,6 @@ jobs:
 
       - name: Install node modules and verify build
         run: npm ci && npm run build-release
-
-      - name: Release
-        if: github.repository == 'morganstanley/needle'
-        uses: justincy/github-action-npm-release@f6afd60cbb595a76ecae037ad006671636d321f5 # 2.0.2
-        id: release
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
-
-      - name: Print release output
-        if: ${{ steps.release.outputs.released == 'true' }}
-        run: echo Release ID ${{ steps.release.outputs.release_id }}
 
       - name: Publish
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
Remove use of github-action-npm-release short term along with publishing on push to main branch.  Workflow will now requires manual run with expectation of package*.json versions being updated and committed to main branch before running.