### PR TITLE
Remove publish condition

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -27,7 +27,6 @@ jobs:
         run: npm ci && npm run build-release
 
       - name: Publish
-        if: steps.release.outputs.released == 'true'
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remove publish condition dependent on now removed github-action-npm-release step.  Since we are manually invoking this action instead of depending on version changes it is not necessary.