### PR TITLE
Update package.json repository url for casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/MorganStanley/needle.git"
+        "url": "https://github.com/morganstanley/needle"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Specific format is required for sigstore to match provenance and sign the package for npm