### PR TITLE
Add support to resolve annotated injection params when using explicit…

### DIFF
--- a/main/constants/constants.ts
+++ b/main/constants/constants.ts
@@ -21,3 +21,14 @@ export const TYPE_NOT_FOUND = { type: 'TYPE_NOT_FOUND' };
  * This constant can be used in conjunction with AutoFactory
  */
 export const AUTO_RESOLVE = undefined;
+
+/**
+ * These values are used when defining explicit metadata and you have no type for the parameter being injected as you maybe using annotation.
+ *
+ * @example @Injectable({metadata: [MyThing, META_DATA.factory, META_DATA.token, META_DATA.strategy]})
+ */
+export const METADATA = {
+    factory: Object,
+    token: Object,
+    strategy: Object,
+};

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -440,7 +440,7 @@ export class Injector implements IInjector {
         const NOT_FOUND = isStringOrSymbol(typeOrToken)
             ? `Cannot resolve Type with token '${typeOrToken.toString()}' as no types have been registered against that token value`
             : `Cannot resolve Type '${
-                  (typeOrToken as any).name
+                  (typeOrToken as any)?.name
               }' as no types have been registered against any injectors`;
 
         const injector = this.getInjectorForTypeOrToken(this, typeOrToken);

--- a/main/core/injector.ts
+++ b/main/core/injector.ts
@@ -501,14 +501,7 @@ export class Injector implements IInjector {
                 // At this point either we have no external resolution or if we did it didn't want to handle it so we must now try
                 if (instance === TYPE_NOT_FOUND || instance == null) {
                     if (registration) {
-                        instance = this.createInstance(
-                            constructorType,
-                            true,
-                            registration,
-                            options as any,
-                            ancestry,
-                            injector,
-                        );
+                        instance = this.createInstance(constructorType, true, options as any, ancestry, injector);
                     } else {
                         this.throwRegistrationNotFound(constructorType, ancestry);
                     }
@@ -556,14 +549,12 @@ export class Injector implements IInjector {
         if (registration == null) {
             this.throwRegistrationNotFound(type, ancestors);
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return this.createInstance(type, updateCache, registration!, options, ancestors, injector);
+        return this.createInstance(type, updateCache, options, ancestors, injector);
     }
 
     private createInstance<T extends new (...args: any[]) => any>(
         type: T,
         updateCache = false,
-        registration: IInjectionConfiguration,
         options?: IConstructionOptionsInternal<T>,
         ancestors: any[] = [],
         injector: IInjector = globalReference[DI_ROOT_INJECTOR_KEY],
@@ -578,7 +569,7 @@ export class Injector implements IInjector {
         }
 
         const overrideParams = (options || {}).params || [];
-        const constructorParamTypes = registration.metadata != null ? registration.metadata : getConstructorTypes(type);
+        const constructorParamTypes = getConstructorTypes(type);
         // Note this call to construct param values introduces recursive behavior
         const constructorParamValues = this.getConstructorParamValues<T>(
             constructorParamTypes,

--- a/main/core/metadata.functions.ts
+++ b/main/core/metadata.functions.ts
@@ -1,3 +1,5 @@
+import { getRootInjector } from './util.functions';
+
 /* Consumers must import the "reflect-metadata" polyfill. */
 declare const Reflect: any;
 
@@ -5,5 +7,12 @@ declare const Reflect: any;
  * Gets an array of types defined in a types constructor
  */
 export function getConstructorTypes<T = unknown>(constr: T): any[] {
-    return Reflect.getMetadata('design:paramtypes', constr) || [];
+    const registration = getRootInjector().getRegistrationForType(constr);
+    if (registration != null && registration.metadata != null) {
+        return registration.metadata;
+    } else if (Reflect != null) {
+        return Reflect.getMetadata('design:paramtypes', constr) || [];
+    }
+
+    return [];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@morgan-stanley/needle",
-    "version": "0.3.27",
+    "version": "0.3.30",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@morgan-stanley/needle",
-            "version": "0.3.27",
+            "version": "0.3.30",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@jsdevtools/coverage-istanbul-loader": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.27",
+    "version": "0.3.30",
     "description": "A small & lightweight dependency injection container for use in multiple contexts like Angular, React & node.",
     "name": "@morgan-stanley/needle",
     "license": "Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -167,7 +167,7 @@ class Owner {
 }
 
 //Equivalent to decorator
-getRootInjector().register(Owner, { metadata: Pet }).register(Pet)
+getRootInjector().register(Owner, { metadata: [Pet] }).register(Pet)
 ```
 
 ## Decorators & Metadata
@@ -187,7 +187,7 @@ class Owner {
 }
 
 //Explicit metadata using the registration API 
-getRootInjector().register(Owner, { metadata: Pet }).register(Pet)
+getRootInjector().register(Owner, { metadata: [Pet] }).register(Pet)
 ```
 
 Note, if you are injecting a token or a strategy etc into a constructor you may not have the type available to you.  In this case you can use following.  

--- a/readme.md
+++ b/readme.md
@@ -43,14 +43,9 @@ The library depends on TypeScript's support for decorators. Therefore you must e
 
 # Polyfills
 
-This library will work with modern browsers and JavaScript run-times without the need for polyfills, however if targeting older browsers like IE11 you will need to provide a polyfill for the following types. 
+This library also makes optional use of the `reflect-metadata` [API](https://rbuckton.github.io/reflect-metadata/) for performing runtime introspection. The library leverages TypeScripts `emitDecoratorMetadata` to support runtime type information being available.  
 
-* Map - [Read about the Map type here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
-* Symbol - [Read about the Symbol type here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)
-
-**Note** Symbol support is optional and only required if you intend to use Symbols for your token registrations.  
-
-This library also makes use of the `reflect-metadata` [API](https://rbuckton.github.io/reflect-metadata/) for performing runtime introspection. Most browsers will not support this therefore you must install this yourself. 
+Most browsers will not support this therefore you must install this yourself. 
 
 ```typescript
 npm install reflect-metadata
@@ -61,6 +56,8 @@ And you should import this module at the root of your application.
 ```typescript
 import "reflect-metadata";
 ```
+
+If you do not want to use this polyfill you can instead adopt the explicit metadata detailed below. 
 
 # Feature support
 
@@ -141,9 +138,6 @@ import "reflect-metadata";
 
 # Injectable basics
 
-## Decorators vs Registration API
-
-This library performs runtime introspection in order to determine what types it should construct.  To do this the library uses metadata and generally this metadata will be implicitly captured for you if you have enabled TypeScripts `emitDecoratorMetadata` and a class is decorated with any decorator. However, you do not need to use decorators if you do not wish to.  In the case where no decorators are applied you will need to manually provide the metadata via the registration API.  **Note** Managing the metadata explicitly can be time consuming so we **recommend using the auto generated metadata approach by default**. 
 
 ## Creating an injectable type
 
@@ -174,6 +168,37 @@ class Owner {
 
 //Equivalent to decorator
 getRootInjector().register(Owner, { metadata: Pet }).register(Pet)
+```
+
+## Decorators & Metadata
+
+This library performs runtime introspection in order to determine what types it should construct.  To do this the library uses metadata and generally this metadata will be implicitly captured for you if you have enabled TypeScripts `emitDecoratorMetadata` and a class is decorated with any decorator. However, you do not need to use decorators or `emitDecoratorMetadata` if you do not wish to.  In that case you will need to manually provide the metadata using a decorator or registration API.  **Note** Managing the metadata explicitly can be time consuming so we **recommend using the auto generated metadata approach by default**.  
+
+```typescript
+import { Injectable } from '@morgan-stanley/needle';
+
+@Injectable()
+class Pet {}
+
+//Explicit metadata via the metadata property on the decorator. 
+@Injectable({ metadata: [Pet]})
+class Owner {
+    constructor(pet: Pet) {}
+}
+
+//Explicit metadata using the registration API 
+getRootInjector().register(Owner, { metadata: Pet }).register(Pet)
+```
+
+Note, if you are injecting a token or a strategy etc into a constructor you may not have the type available to you.  In this case you can use following.  
+
+```typescript
+import { Injectable, METADATA } from '@morgan-stanley/needle';
+
+@Injectable({ metadata: [METADATA.token]})
+class Owner {
+    constructor(@Inject('my-pet') pet: IPet) {}
+}
 ```
 
 ## Resolving injectables


### PR DESCRIPTION
When using explcit metadata we need to provide readable metadata types where the type cannot be imported (for example circular ref scenarios)

```typescript
import { Injectable, METADATA } from '@morgan-stanley/needle';

@Injectable({ metadata: [METADATA.token]})
class Owner {
    constructor(@Inject('my-pet') pet: IPet) {}
}
```