### PR TITLE
ci(release): remove npm token env variable, use trusted publishers

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -28,5 +28,3 @@ jobs:
 
       - name: Publish
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Replace explicit NPM_TOKEN environment variable with OIDC-based trusted publishing for enhanced security and simplified token management.